### PR TITLE
bugfix: Prevent change answer on page reload

### DIFF
--- a/assets/js/quiz.js
+++ b/assets/js/quiz.js
@@ -161,7 +161,6 @@ function checkAnswer() {
       quizProgress[currentStep] = "correct";
       countdownEl.textContent = "Rätt svar! Klicka för att gå vidare";
       countdownEl.classList.add("countdown--correct");
-      // selectedOption.closest("label").classList.add("answer-option--correct");
       score++;
     } else {
       // incorrect
@@ -172,6 +171,8 @@ function checkAnswer() {
     }
   }
 
+  localStorage.setItem("countdownTime", "∞");
+  saveQuiz(score, currentStep, questions, totalQuestions, quizProgress);
   printProgress();
   readyNext.style.display = "block";
 }
@@ -181,6 +182,11 @@ addEventListener("outOfTime", handleOutOfTime);
 
 // Eventlistener on overlay for click to continue
 readyNext.addEventListener("click", goToNext);
+
+// When countdownTime in localstorage is stopped ("∞")
+if (localStorage.getItem("countdownTime") === "∞") {
+  goToNext();
+}
 
 // Run this after main loader
 startQuiz();

--- a/assets/js/services/timer.js
+++ b/assets/js/services/timer.js
@@ -24,7 +24,7 @@ function startTimer(countdownDisplay) {
   }
 
   countdownInterval = setInterval(printCountdown, 1000);
-  timeOut = setTimeout(() => handleTimeout(countdownDisplay), countdownInitialTime * 1000); // Do we need timeOut?
+  timeOut = setTimeout(() => handleTimeout(countdownDisplay), countdownInitialTime * 1000);
 }
 
 function stopTimer() {


### PR DESCRIPTION
When answer is clicked or answer timeout, countdown is set to "∞", "∞" is checked on reload and redirected to next question.